### PR TITLE
Add custom StoredProperty decorator

### DIFF
--- a/apps/fretonator-web/src/app/common/fretonator/fretboard/fretboard.component.html
+++ b/apps/fretonator-web/src/app/common/fretonator/fretboard/fretboard.component.html
@@ -84,9 +84,9 @@
       [tonicActive]="highlightedDegrees.has(scaleDegree.tonic)"
       [mediantActive]="highlightedDegrees.has(scaleDegree.mediant)"
       [dominantActive]="highlightedDegrees.has(scaleDegree.dominant)"
-      (setTonicHighlight)="toggleHighlightTonic()"
-      (setMediantHighlight)="toggleHighlightMediant()"
-      (setDominantHighlight)="toggleHighlightDominant()"
+      (setTonicHighlight)="toggleHighlight(scaleDegree.tonic)"
+      (setMediantHighlight)="toggleHighlight(scaleDegree.mediant)"
+      (setDominantHighlight)="toggleHighlight(scaleDegree.dominant)"
     ></app-scale-degrees>
   </div>
 


### PR DESCRIPTION
This commit adds a `@StoredProperty` decorator that will read the
property from localstorage at component startup (ngOnInit) and define
the property as a setter that writes it to localStorage. This makes
using persisted properties very easy.

Unfortunately, it doesn't work at all because Angular will not take into account any modifications to lifecycle hooks that are done in decorators. See https://github.com/angular/angular/pull/35464

Maybe once that is merged, this PR can be picked back up, until then, leaving the PR open as documentation of the issue.